### PR TITLE
adding JavaFX dependencies and shade plugin to manually include JavaFX class files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,26 @@
             <groupId>org.slf4j</groupId>
             <version>1.6.5</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>13</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -57,6 +76,29 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.openjfx:javafx-controls</include>
+                                    <include>org.openjfx:javafx-fxml</include>
+                                    <include>org.openjfx:javafx-base</include>
+                                    <include>org.openjfx:javafx-graphics</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
The recommended method for including the JavaFX library directly is to use Maven and add as a direct dependency.  To ensure the correct version is available regardless of JRE version the maven shade plugin allows us to add the required classes to the jar directly.  On build the required classes will be loaded by default into the generated JAR file.