### PR TITLE
Previous Season Point Weight

### DIFF
--- a/configs/savedRankWeight.yaml
+++ b/configs/savedRankWeight.yaml
@@ -1,5 +1,5 @@
 !!edu.umuc.models.RankWeight
 avgOppDifference: 0.25
-lastSeasonPercentWeight: 0.0
+lastSeasonPercentWeight: 0.5
 oppWins: 0.65
 winLoss: 0.85

--- a/configs/savedRankWeight.yaml
+++ b/configs/savedRankWeight.yaml
@@ -1,4 +1,5 @@
 !!edu.umuc.models.RankWeight
 avgOppDifference: 0.25
+lastSeasonPercentWeight: 0.0
 oppWins: 0.65
 winLoss: 0.85

--- a/configs/savedRankWeight.yaml
+++ b/configs/savedRankWeight.yaml
@@ -1,5 +1,5 @@
 !!edu.umuc.models.RankWeight
 avgOppDifference: 0.25
-lastSeasonPercentWeight: 0.15
+lastSeasonPercentWeight: 0.0
 oppWins: 0.65
 winLoss: 0.85

--- a/configs/savedRankWeight.yaml
+++ b/configs/savedRankWeight.yaml
@@ -1,5 +1,5 @@
 !!edu.umuc.models.RankWeight
 avgOppDifference: 0.25
-lastSeasonPercentWeight: 0.5
+lastSeasonPercentWeight: 0.15
 oppWins: 0.65
 winLoss: 0.85

--- a/configs/savedRankWeight.yaml
+++ b/configs/savedRankWeight.yaml
@@ -1,5 +1,5 @@
 !!edu.umuc.models.RankWeight
 avgOppDifference: 0.25
-lastSeasonPercentWeight: 0.0
+lastSeasonPercentWeight: 0.15
 oppWins: 0.65
 winLoss: 0.85

--- a/src/main/java/edu/umuc/controllers/GetDataThread.java
+++ b/src/main/java/edu/umuc/controllers/GetDataThread.java
@@ -85,8 +85,6 @@ class GetDataThread implements Runnable {
                  */
                 String url = "https://www.washingtonpost.com/allmetsports/" + year + "-" + season + "/" + school.getUrlPath() + "/" + sport + "/";
 
-                System.out.println("URL!!! - " + url);
-
                 /**
                  * Get the data within the specified timeout period
                  */

--- a/src/main/java/edu/umuc/controllers/GetDataThread.java
+++ b/src/main/java/edu/umuc/controllers/GetDataThread.java
@@ -85,6 +85,8 @@ class GetDataThread implements Runnable {
                  */
                 String url = "https://www.washingtonpost.com/allmetsports/" + year + "-" + season + "/" + school.getUrlPath() + "/" + sport + "/";
 
+                System.out.println("URL!!! - " + url);
+
                 /**
                  * Get the data within the specified timeout period
                  */

--- a/src/main/java/edu/umuc/controllers/ManageWeightsController.java
+++ b/src/main/java/edu/umuc/controllers/ManageWeightsController.java
@@ -34,6 +34,9 @@ public class ManageWeightsController extends Controller implements Initializable
     @FXML
     private TextField avgPtsDiffWeight;
 
+    @FXML
+    private TextField lastSeasonPercentCalc;
+
     /**
      * Default Constructor
      */
@@ -53,6 +56,7 @@ public class ManageWeightsController extends Controller implements Initializable
         winLossWeight.setText(DECIMAL_FORMAT.format(rankWeight.getWinLoss()));
         oppWinsWeight.setText(DECIMAL_FORMAT.format(rankWeight.getOppWins()));
         avgPtsDiffWeight.setText(DECIMAL_FORMAT.format(rankWeight.getAvgOppDifference()));
+        lastSeasonPercentCalc.setText(DECIMAL_FORMAT.format(rankWeight.getLastSeasonPercentWeight()));
     }
 
     /**
@@ -68,7 +72,8 @@ public class ManageWeightsController extends Controller implements Initializable
                 final Float winLoss = Float.parseFloat(winLossWeight.getText());
                 final Float oppWins = Float.parseFloat(oppWinsWeight.getText());
                 final Float avgOppDifference = Float.parseFloat(avgPtsDiffWeight.getText());
-                final RankWeight savedRankWeight = new RankWeight(winLoss, oppWins, avgOppDifference);
+                final Float lastSeason = Float.parseFloat(lastSeasonPercentCalc.getText());
+                final RankWeight savedRankWeight = new RankWeight(winLoss, oppWins, avgOppDifference, lastSeason);
                 setRankWeight(savedRankWeight);
 
                 /**
@@ -80,6 +85,7 @@ public class ManageWeightsController extends Controller implements Initializable
                 winLossWeight.setText(DECIMAL_FORMAT.format(savedRankWeight.getWinLoss()));
                 oppWinsWeight.setText(DECIMAL_FORMAT.format(savedRankWeight.getOppWins()));
                 avgPtsDiffWeight.setText(DECIMAL_FORMAT.format(savedRankWeight.getAvgOppDifference()));
+                lastSeasonPercentCalc.setText(DECIMAL_FORMAT.format(savedRankWeight.getLastSeasonPercentWeight()));
 
             } catch (NumberFormatException e){
                 /**
@@ -106,6 +112,7 @@ public class ManageWeightsController extends Controller implements Initializable
             winLossWeight.setText(DECIMAL_FORMAT.format(rankWeight.getWinLoss()));
             oppWinsWeight.setText(DECIMAL_FORMAT.format(rankWeight.getOppWins()));
             avgPtsDiffWeight.setText(DECIMAL_FORMAT.format(rankWeight.getAvgOppDifference()));
+            lastSeasonPercentCalc.setText(DECIMAL_FORMAT.format(rankWeight.getLastSeasonPercentWeight()));
 
             /**
              * "Autosave" default values on reset

--- a/src/main/java/edu/umuc/controllers/RankCalculationController.java
+++ b/src/main/java/edu/umuc/controllers/RankCalculationController.java
@@ -149,19 +149,19 @@ public class RankCalculationController extends Controller implements Initializab
         float averagePointDifferenceWeight = getRankWeight().getAvgOppDifference();
         float lastSeasonPercentWeight = getRankWeight().getLastSeasonPercentWeight();
         float previousYearPoints = getSelectedSchool().getPreviousYearPoints();
-        float valAverageOpponentWins = opponentSize == 0 ? 0 : opponentTotalWins / opponentSize;
+        float averageOpponentWins = opponentSize == 0 ? 0 : opponentTotalWins / opponentSize;
         float valPoints = (wins - losses) * winLossWeight;
         float valPointsOpponentWins = opponentSize == 0 ? 0 : (opponentTotalWins / opponentSize) * opponentWinWeight;
         float valDifferential = averagePointDifference * averagePointDifferenceWeight;
         float valLastSeason = lastSeasonPercentWeight == 0 ? 0 : previousYearPoints * lastSeasonPercentWeight;
-        float valTotal = valAverageOpponentWins + valPoints + valPointsOpponentWins + valDifferential + valLastSeason;
+        float valTotal = valPoints + valPointsOpponentWins + valDifferential + valLastSeason;
 
-        textArea.setText("Average Opponent Wins: Opponents Wins (" + opponentTotalWins + ") " + " divided by the Opponent size (" + opponentSize + ") equaling " + DECIMAL_FORMAT.format(valAverageOpponentWins) + "\n" +
+        textArea.setText("Average Opponent Wins: Opponents Wins (" + opponentTotalWins + ") " + " divided by the Opponent size (" + opponentSize + ") equaling " + DECIMAL_FORMAT.format(averageOpponentWins) + "\n" +
                 "Sum of Points: Team wins (" + wins + ") minus team losses (" + losses + ") times the Win-Loss Weight (" + winLossWeight + ") " + " equaling " + DECIMAL_FORMAT.format(valPoints) + "\n" +
                 "Points from Opponents Wins: Average Opponent Wins (" + DECIMAL_FORMAT.format(opponentSize == 0 ? 0 : opponentTotalWins / opponentSize) + ") times the Opponent Points Weight (" + opponentWinWeight + ") equaling " + DECIMAL_FORMAT.format(valPointsOpponentWins) + "\n" +
                 "Points from Average Point Differential: Average point difference (" + DECIMAL_FORMAT.format(averagePointDifference) + ") times the Avg Point Difference (" + averagePointDifferenceWeight + ") equaling " + DECIMAL_FORMAT.format(valDifferential) + "\n" +
                 (lastSeasonPercentWeight > 0 ? "Points from Last Season: Total Points (" + DECIMAL_FORMAT.format(previousYearPoints) + ") times Last Season Weight (" + DECIMAL_FORMAT.format(lastSeasonPercentWeight) + ") equaling  " + DECIMAL_FORMAT.format(valLastSeason) + "\n" : "") +
-                "Total Points: " + DECIMAL_FORMAT.format(valAverageOpponentWins) + " + " + DECIMAL_FORMAT.format(valPoints) + " + " + DECIMAL_FORMAT.format(valPointsOpponentWins) + " + " + DECIMAL_FORMAT.format(valDifferential) + " + " + (lastSeasonPercentWeight > 0 ? DECIMAL_FORMAT.format(valLastSeason) : "") + " = " + DECIMAL_FORMAT.format(valTotal) + "\n\n\n\n\n\n\n\n");
+                "Total Points: " + DECIMAL_FORMAT.format(valPoints) + " + " + DECIMAL_FORMAT.format(valPointsOpponentWins) + " + " + DECIMAL_FORMAT.format(valDifferential) + (lastSeasonPercentWeight > 0 ? " + " + DECIMAL_FORMAT.format(valLastSeason) : "") + " = " + DECIMAL_FORMAT.format(valTotal) + "\n\n\n\n\n\n\n\n");
     }
 
     /**

--- a/src/main/java/edu/umuc/controllers/RankCalculationController.java
+++ b/src/main/java/edu/umuc/controllers/RankCalculationController.java
@@ -3,8 +3,10 @@ package edu.umuc.controllers;
 import edu.umuc.models.League;
 import edu.umuc.models.RankWeight;
 import edu.umuc.models.School;
+
 import java.net.URL;
 import java.util.ResourceBundle;
+
 import javafx.beans.property.SimpleFloatProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -23,7 +25,7 @@ import javafx.scene.control.cell.PropertyValueFactory;
  */
 public class RankCalculationController extends Controller implements Initializable {
 
-    /** 
+    /**
      * The School Results TableView and associated columns
      */
     @FXML
@@ -56,7 +58,7 @@ public class RankCalculationController extends Controller implements Initializab
     @FXML
     private TableColumn<RankCalculationController.FXResultsTable, String> avgPointDifferential;
 
-    /** 
+    /**
      * The Calculation TableView and associated columns
      */
     @FXML
@@ -76,10 +78,10 @@ public class RankCalculationController extends Controller implements Initializab
 
     @FXML
     private TableColumn<RankCalculationController.FXCalculationTable, String> pointsFromAvgOppDiff;
-    
+
     @FXML
     private TableColumn<RankCalculationController.FXCalculationTable, String> totalPoints;
-    
+
     @FXML
     private Label textArea;
 
@@ -91,17 +93,18 @@ public class RankCalculationController extends Controller implements Initializab
 
     @FXML
     private Label lblSchoolName;
- 
-    /** 
+
+    /**
      * Default constructor
      */
     public RankCalculationController() {
     }
-    
+
     /**
      * Sets up the tables and populates the data
+     *
      * @param location
-     * @param resources 
+     * @param resources
      */
     @Override
     public void initialize(URL location, ResourceBundle resources) {
@@ -114,17 +117,17 @@ public class RankCalculationController extends Controller implements Initializab
         weightAvgPointsScored.setCellValueFactory(new PropertyValueFactory<>("avgPointDiffWeight"));
         oppWins.setCellValueFactory(new PropertyValueFactory<>("oppWins"));
         avgPointDifferential.setCellValueFactory(new PropertyValueFactory<>("avgPointDiff"));
-        
+
         pointsForWin.setCellValueFactory(new PropertyValueFactory<>("pointsForWins"));
         pointsForLosses.setCellValueFactory(new PropertyValueFactory<>("pointsForLosses"));
         sumOfPoints.setCellValueFactory(new PropertyValueFactory<>("sumOfPoints"));
         pointsFromOppWins.setCellValueFactory(new PropertyValueFactory<>("pointsFromOpponentWins"));
         pointsFromAvgOppDiff.setCellValueFactory(new PropertyValueFactory<>("pointsFromAveragePointDiff"));
         totalPoints.setCellValueFactory(new PropertyValueFactory<>("totalPoints"));
-        
+
         final ObservableList<RankCalculationController.FXResultsTable> result = FXCollections.observableArrayList();
         final ObservableList<RankCalculationController.FXCalculationTable> calculation = FXCollections.observableArrayList();
-        
+
         if (getSelectedSchool() != null) {
             lblSchoolName.setText(getSelectedSchool().getSchoolName() + " Results");
             result.add(new FXResultsTable(getSelectedLeague(), getSelectedSchool(), getRankWeight()));
@@ -134,27 +137,34 @@ public class RankCalculationController extends Controller implements Initializab
         }
         tbSchoolResults.setItems(result);
         tbCalculation.setItems(calculation);
-        
-        textArea.setText("Average Opponent Wins is: Opponents Wins (" + getSelectedSchool().getOpponentsTotalWins() + 
-                            ") divided by the Opponent size (" +getSelectedSchool().getOpponents().size()+") equaling " + 
-                            String.valueOf(DECIMAL_FORMAT.format(getSelectedSchool().getOpponents().size() == 0 ? 0 : getSelectedSchool().getOpponentsTotalWins() /getSelectedSchool().getOpponents().size())) +"\n" +
-                         "Sum of Points is: Team wins (" + getSelectedSchool().getWins() + ") minus team losses (" + getSelectedSchool().getLosses() + 
-                            ") times the Win-Loss Weight (" + getRankWeight().getWinLoss() +") equaling " + 
-                            String.valueOf(DECIMAL_FORMAT.format((getSelectedSchool().getWins() - getSelectedSchool().getLosses()) * getRankWeight().getWinLoss())) + "\n" +
-                         "Points from Opponents Wins is: Average Opponent Wins (" + DECIMAL_FORMAT.format(getSelectedSchool().getOpponents().size() == 0 ? 0 : getSelectedSchool().getOpponentsTotalWins() /getSelectedSchool().getOpponents().size()) +
-                            ") times the Opponent Points Weight (" + getRankWeight().getOppWins() + ") equaling " + 
-                            DECIMAL_FORMAT.format((getSelectedSchool().getOpponents().size() == 0 ? 0 : getSelectedSchool().getOpponentsTotalWins() /getSelectedSchool().getOpponents().size()) * getRankWeight().getOppWins()) + "\n" +
-                         "Points from Avg. Point Differential is: Average point difference (" + DECIMAL_FORMAT.format(getSelectedSchool().getAvgPointDifference()) + ") times the Avg Point Difference (" + 
-                            getRankWeight().getAvgOppDifference() +") equaling "+ DECIMAL_FORMAT.format(getSelectedSchool().getAvgPointDifference() * getRankWeight().getAvgOppDifference()) + "\n" +
-                         "Total Points is: Sum of Points (" + DECIMAL_FORMAT.format((getSelectedSchool().getWins() - getSelectedSchool().getLosses()) * getRankWeight().getWinLoss() )+ 
-                            ") plus the Pts from Opponents Wins (" + DECIMAL_FORMAT.format((getSelectedSchool().getOpponents().size() == 0 ? 0 : getSelectedSchool().getOpponentsTotalWins() /getSelectedSchool().getOpponents().size()) * getRankWeight().getOppWins()) +
-                            ") plus the Pts from Avg Point Differential (" + DECIMAL_FORMAT.format(getSelectedSchool().getAvgPointDifference() * getRankWeight().getAvgOppDifference()) + ") equaling " +
-                            DECIMAL_FORMAT.format((((getSelectedSchool().getWins() - getSelectedSchool().getLosses()) * getRankWeight().getWinLoss()) + 
-                            (getSelectedSchool().getOpponents().size() == 0 ? 0 : (getSelectedSchool().getOpponentsTotalWins() /getSelectedSchool().getOpponents().size()) * getRankWeight().getOppWins()) +
-                            (getSelectedSchool().getAvgPointDifference() * getRankWeight().getAvgOppDifference()))) + "\n\n\n\n\n\n\n\n");
+
+        //Added for readability
+        float opponentTotalWins = getSelectedSchool().getOpponentsTotalWins();
+        float opponentSize = getSelectedSchool().getOpponents().size();
+        float wins = getSelectedSchool().getWins();
+        float losses = getSelectedSchool().getLosses();
+        float winLossWeight = getRankWeight().getWinLoss();
+        float opponentWinWeight = getRankWeight().getOppWins();
+        float averagePointDifference = getSelectedSchool().getAvgPointDifference();
+        float averagePointDifferenceWeight = getRankWeight().getAvgOppDifference();
+        float lastSeasonPercentWeight = getRankWeight().getLastSeasonPercentWeight();
+        float previousYearPoints = getSelectedSchool().getPreviousYearPoints();
+        float valAverageOpponentWins = opponentSize == 0 ? 0 : opponentTotalWins / opponentSize;
+        float valPoints = (wins - losses) * winLossWeight;
+        float valPointsOpponentWins = opponentSize == 0 ? 0 : (opponentTotalWins / opponentSize) * opponentWinWeight;
+        float valDifferential = averagePointDifference * averagePointDifferenceWeight;
+        float valLastSeason = lastSeasonPercentWeight == 0 ? 0 : previousYearPoints * lastSeasonPercentWeight;
+        float valTotal = valAverageOpponentWins + valPoints + valPointsOpponentWins + valDifferential + valLastSeason;
+
+        textArea.setText("Average Opponent Wins: Opponents Wins (" + opponentTotalWins + ") " + " divided by the Opponent size (" + opponentSize + ") equaling " + DECIMAL_FORMAT.format(valAverageOpponentWins) + "\n" +
+                "Sum of Points: Team wins (" + wins + ") minus team losses (" + losses + ") times the Win-Loss Weight (" + winLossWeight + ") " + " equaling " + DECIMAL_FORMAT.format(valPoints) + "\n" +
+                "Points from Opponents Wins: Average Opponent Wins (" + DECIMAL_FORMAT.format(opponentSize == 0 ? 0 : opponentTotalWins / opponentSize) + ") times the Opponent Points Weight (" + opponentWinWeight + ") equaling " + DECIMAL_FORMAT.format(valPointsOpponentWins) + "\n" +
+                "Points from Average Point Differential: Average point difference (" + DECIMAL_FORMAT.format(averagePointDifference) + ") times the Avg Point Difference (" + averagePointDifferenceWeight + ") equaling " + DECIMAL_FORMAT.format(valDifferential) + "\n" +
+                (lastSeasonPercentWeight > 0 ? "Points from Last Season: Total Points (" + DECIMAL_FORMAT.format(previousYearPoints) + ") times Last Season Weight (" + DECIMAL_FORMAT.format(lastSeasonPercentWeight) + ") equaling  " + DECIMAL_FORMAT.format(valLastSeason) + "\n" : "") +
+                "Total Points: " + DECIMAL_FORMAT.format(valAverageOpponentWins) + " + " + DECIMAL_FORMAT.format(valPoints) + " + " + DECIMAL_FORMAT.format(valPointsOpponentWins) + " + " + DECIMAL_FORMAT.format(valDifferential) + " + " + (lastSeasonPercentWeight > 0 ? DECIMAL_FORMAT.format(valLastSeason) : "") + " = " + DECIMAL_FORMAT.format(valTotal) + "\n\n\n\n\n\n\n\n");
     }
-    
-    /** 
+
+    /**
      * Class created for the Results table
      */
     public class FXResultsTable {
@@ -168,7 +178,7 @@ public class RankCalculationController extends Controller implements Initializab
         private final SimpleStringProperty oppWins;
         private final SimpleStringProperty avgPointDiff;
 
-        
+
         private FXResultsTable(League league, School school, RankWeight rankWeight) {
             this.wins = new SimpleIntegerProperty(school.getWins());
             this.losses = new SimpleIntegerProperty(school.getLosses());
@@ -177,7 +187,7 @@ public class RankCalculationController extends Controller implements Initializab
             this.winLossWeight = new SimpleFloatProperty(rankWeight.getWinLoss());
             this.oppWinWeight = new SimpleFloatProperty(rankWeight.getOppWins());
             this.avgPointDiffWeight = new SimpleFloatProperty(rankWeight.getAvgOppDifference());
-            this.oppWins =  new SimpleStringProperty(String.valueOf(DECIMAL_FORMAT.format(school.getOpponents().size() == 0 ? 0 : school.getOpponentsTotalWins()/school.getOpponents().size())));
+            this.oppWins = new SimpleStringProperty(String.valueOf(DECIMAL_FORMAT.format(school.getOpponents().size() == 0 ? 0 : school.getOpponentsTotalWins() / school.getOpponents().size())));
             this.avgPointDiff = new SimpleStringProperty(DECIMAL_FORMAT.format(school.getAvgPointDifference()));
         }
 
@@ -216,7 +226,7 @@ public class RankCalculationController extends Controller implements Initializab
         public SimpleStringProperty avgPointDiffProperty() {
             return avgPointDiff;
         }
-        
+
         public int getWins() {
             return wins.get();
         }
@@ -255,9 +265,9 @@ public class RankCalculationController extends Controller implements Initializab
 
     }
 
-    /** 
+    /**
      * Class created for the Calculation table
-     */    
+     */
     public class FXCalculationTable {
         private final SimpleStringProperty pointsForWins;
         private final SimpleStringProperty pointsForLosses;
@@ -265,7 +275,7 @@ public class RankCalculationController extends Controller implements Initializab
         private final SimpleStringProperty pointsFromOpponentWins;
         private final SimpleStringProperty pointsFromAveragePointDiff;
         private final SimpleStringProperty totalPoints;
-        
+
         private FXCalculationTable(League league, School school, RankWeight rankWeight) {
             this.pointsForWins = new SimpleStringProperty(DECIMAL_FORMAT.format(school.getPointsForWins(league.getWeight())));
             this.pointsForLosses = new SimpleStringProperty(DECIMAL_FORMAT.format(school.getPointsForLosses(league.getWeight())));
@@ -281,15 +291,15 @@ public class RankCalculationController extends Controller implements Initializab
 
         public String getPointsForWins() {
             return pointsForWins.get();
-        }        
-        
+        }
+
         public SimpleStringProperty pointsForLossesProperty() {
             return pointsForLosses;
         }
 
         public String getPointsForLosses() {
             return pointsForLosses.get();
-        } 
+        }
 
         public SimpleStringProperty sumOfPointsProperty() {
             return sumOfPoints;
@@ -297,7 +307,7 @@ public class RankCalculationController extends Controller implements Initializab
 
         public String getSumOfPoints() {
             return sumOfPoints.get();
-        } 
+        }
 
         public SimpleStringProperty pointsFromOpponentWinsProperty() {
             return pointsFromOpponentWins;
@@ -305,7 +315,7 @@ public class RankCalculationController extends Controller implements Initializab
 
         public String getPointsFromOpponentWins() {
             return pointsFromOpponentWins.get();
-        } 
+        }
 
         public SimpleStringProperty pointsFromAveragePointDiffProperty() {
             return pointsFromAveragePointDiff;
@@ -313,7 +323,7 @@ public class RankCalculationController extends Controller implements Initializab
 
         public String getPointsFromAveragePointDiff() {
             return pointsFromAveragePointDiff.get();
-        } 
+        }
 
         public SimpleStringProperty totalPointsProperty() {
             return totalPoints;

--- a/src/main/java/edu/umuc/controllers/SchoolRankingController.java
+++ b/src/main/java/edu/umuc/controllers/SchoolRankingController.java
@@ -105,6 +105,9 @@ public class SchoolRankingController extends Controller implements Initializable
     @FXML
     private Label lblAvgPointDiff;
 
+    @FXML
+    private Label lblPreviousSeason;
+
     private String savedYearChoice;
 
     private Sport savedSportChoice;
@@ -203,6 +206,7 @@ public class SchoolRankingController extends Controller implements Initializable
         lblWinLoss.setText(decimalFormat.format(rankWeight.getWinLoss()));
         lblOppWins.setText(decimalFormat.format(rankWeight.getOppWins()));
         lblAvgPointDiff.setText(decimalFormat.format(rankWeight.getAvgOppDifference()));
+        lblPreviousSeason.setText(decimalFormat.format(rankWeight.getLastSeasonPercentWeight()));
     }
 
     /**
@@ -274,6 +278,7 @@ public class SchoolRankingController extends Controller implements Initializable
                      * selections
                      */
                     final ScrapeData scrapeData = new ScrapeData();
+                    final List<School> previousYearSchools = scrapeData.scrapeData(String.valueOf(Integer.parseInt(getYearSelected())-1), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
                     final List<School> schools = scrapeData.scrapeData(getYearSelected(), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
 
                     /**

--- a/src/main/java/edu/umuc/controllers/SchoolRankingController.java
+++ b/src/main/java/edu/umuc/controllers/SchoolRankingController.java
@@ -28,7 +28,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import static java.util.Collections.list;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
@@ -277,19 +280,22 @@ public class SchoolRankingController extends Controller implements Initializable
                      */
                     final ScrapeData scrapeData = new ScrapeData();
                     List<School> previousYearSchools = null;
+                    Map<String,School> previousYearSchoolMap = new HashMap<>();
                     if(rankWeight.getLastSeasonPercentWeight() > 0){
                         previousYearSchools = scrapeData.scrapeData(String.valueOf(Integer.parseInt(getYearSelected()) - 1), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
                     }
 
                     final List<School> schools = scrapeData.scrapeData(getYearSelected(), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
 
-                    if(previousYearSchools != null){
-                        for(School school : schools){
-                            for(School previousSchool : previousYearSchools){
-                                if(school.getSchoolName().equals(previousSchool.getSchoolName())){
-                                    school.setPreviousYearPoints(previousSchool.getTotalPoints(rankWeight,getLeagueWeightForSchool(school.getSchoolName())));
-                                }
-                            }
+                    if(previousYearSchools != null) {
+                        for(School school : previousYearSchools) {
+                            previousYearSchoolMap.putIfAbsent(school.getSchoolName(), school);
+                        }
+                    }
+
+                    for(School school : schools){
+                        if(previousYearSchoolMap.get(school.getSchoolName()) != null){
+                            school.setPreviousYearPoints(previousYearSchoolMap.get(school.getSchoolName()).getTotalPoints(rankWeight,getLeagueWeightForSchool(school.getSchoolName())));
                         }
                     }
 

--- a/src/main/java/edu/umuc/controllers/SchoolRankingController.java
+++ b/src/main/java/edu/umuc/controllers/SchoolRankingController.java
@@ -115,7 +115,7 @@ public class SchoolRankingController extends Controller implements Initializable
     @FXML
     public ChoiceBox<String> filterChoice;
     
-               @FXML
+    @FXML
     private Button btnExportCSV;
 
     /**
@@ -216,9 +216,6 @@ public class SchoolRankingController extends Controller implements Initializable
      */
     @FXML
     private void processRankSchoolsEvent(ActionEvent event) {
-
-
-
         if (savedYearChoice == yearChoice.getValue()
                 && savedSportChoice == sportChoice.getValue()) {
             return;
@@ -235,7 +232,8 @@ public class SchoolRankingController extends Controller implements Initializable
 
         final RankWeight rankWeight = new RankWeight(Float.parseFloat(lblWinLoss.getText()),
                 Float.parseFloat(lblOppWins.getText()),
-                Float.parseFloat(lblAvgPointDiff.getText()));
+                Float.parseFloat(lblAvgPointDiff.getText()),
+                Float.parseFloat(lblPreviousSeason.getText()));
 
         final Sport sportSelected = getSports().stream()
                 .filter(sportItem -> getSportSelected().getName().equals(sportItem.getName()))
@@ -278,8 +276,22 @@ public class SchoolRankingController extends Controller implements Initializable
                      * selections
                      */
                     final ScrapeData scrapeData = new ScrapeData();
-                    final List<School> previousYearSchools = scrapeData.scrapeData(String.valueOf(Integer.parseInt(getYearSelected())-1), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
+                    List<School> previousYearSchools = null;
+                    if(rankWeight.getLastSeasonPercentWeight() > 0){
+                        previousYearSchools = scrapeData.scrapeData(String.valueOf(Integer.parseInt(getYearSelected()) - 1), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
+                    }
+
                     final List<School> schools = scrapeData.scrapeData(getYearSelected(), sportSelected.getSeason(), sportSelected.getPath(), rankWeight);
+
+                    if(previousYearSchools != null){
+                        for(School school : schools){
+                            for(School previousSchool : previousYearSchools){
+                                if(school.getSchoolName().equals(previousSchool.getSchoolName())){
+                                    school.setPreviousYearPoints(previousSchool.getTotalPoints(rankWeight,getLeagueWeightForSchool(school.getSchoolName())));
+                                }
+                            }
+                        }
+                    }
 
                     /**
                      * Flag used to determine if schools have been ranked
@@ -316,12 +328,7 @@ public class SchoolRankingController extends Controller implements Initializable
         Thread thTask = new Thread(task);
         thTask.start();
         savedYearChoice = yearChoice.getValue();
-        savedSportChoice = sportChoice.getValue();
-
-
-   
-          
-    }
+        savedSportChoice = sportChoice.getValue();}
 
     private void populateTable(List<School> schools) {
         rankedSchools.clear();

--- a/src/main/java/edu/umuc/fxml/ManageWeights.fxml
+++ b/src/main/java/edu/umuc/fxml/ManageWeights.fxml
@@ -11,76 +11,111 @@
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="1100.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.umuc.controllers.ManageWeightsController">
-   <children>
-      <GridPane layoutY="160.0" prefHeight="440.0" prefWidth="1100.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="160.0">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" />
-          <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="240.0" minWidth="240.0" prefWidth="240.0" />
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="25.0" minWidth="25.0" prefWidth="25.0" />
-          <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" maxWidth="180.0" minWidth="180.0" prefWidth="180.0" />
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" />
-        </columnConstraints>
-        <rowConstraints>
-            <RowConstraints maxHeight="91.0" minHeight="10.0" prefHeight="60.0" vgrow="SOMETIMES" />
-          <RowConstraints maxHeight="60.0" minHeight="60.0" prefHeight="60.0" vgrow="SOMETIMES" />
-          <RowConstraints maxHeight="60.0" minHeight="60.0" prefHeight="60.0" vgrow="SOMETIMES" />
-          <RowConstraints maxHeight="60.0" minHeight="60.0" prefHeight="60.0" vgrow="SOMETIMES" />
-            <RowConstraints maxHeight="1.7976931348623157E308" vgrow="SOMETIMES" />
-            <RowConstraints maxHeight="80.0" minHeight="80.0" prefHeight="80.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <Label prefHeight="30.0" prefWidth="88.0" text="Win-Loss" GridPane.columnIndex="1" GridPane.rowIndex="1">
-               <font>
-                  <Font name="Times New Roman" size="20.0" />
-               </font>
-            </Label>
-            <TextField fx:id="winLossWeight" GridPane.columnIndex="3" GridPane.rowIndex="1" />
-            <Label prefHeight="30.0" prefWidth="210" text="Average Opponents Wins" GridPane.columnIndex="1" GridPane.rowIndex="2">
-               <font>
-                  <Font name="Times New Roman" size="20.0" />
-               </font>
-            </Label>
-            <TextField fx:id="oppWinsWeight" GridPane.columnIndex="3" GridPane.rowIndex="2" />
-            <Label prefHeight="30.0" prefWidth="210.0" text="Average Point Difference" GridPane.columnIndex="1" GridPane.rowIndex="3">
-               <font>
-                  <Font name="Times New Roman" size="20.0" />
-               </font>
-            </Label>
-            <TextField fx:id="avgPtsDiffWeight" prefHeight="31.0" prefWidth="190.0" GridPane.columnIndex="3" GridPane.rowIndex="3" />
-            <Label prefHeight="48.0" prefWidth="67.0" text="Type" GridPane.columnIndex="1">
-               <font>
-                  <Font name="Times New Roman" size="29.0" />
-               </font>
-            </Label>
-            <Label prefHeight="48.0" prefWidth="91.0" text="Weight" GridPane.columnIndex="3" GridPane.halignment="CENTER">
-               <font>
-                  <Font name="Times New Roman" size="29.0" />
-               </font>
-            </Label>
-            <Button fx:id="btnResetWeights" mnemonicParsing="false" onAction="#handleResetWeights" prefHeight="42.0" prefWidth="191.0" text="Reset Weights" textFill="#29288d" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-            <Button fx:id="btnSaveWeights" mnemonicParsing="false" onAction="#handleSaveWeights" prefHeight="42.0" prefWidth="191.0" text="Save Weights" textFill="#29288d" GridPane.columnIndex="3" GridPane.rowIndex="5" />
-         </children>
-      </GridPane>
-      <AnchorPane prefHeight="110.0" prefWidth="1100.0" style="-fx-background-color: #23a353;" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-         <children>
-            <Label alignment="CENTER" layoutX="353.0" layoutY="20.0" prefHeight="70.0" prefWidth="395.0" text="Manage Weights" textFill="WHITE" AnchorPane.leftAnchor="30.0" AnchorPane.rightAnchor="30.0" AnchorPane.topAnchor="20.0">
-               <font>
-                  <Font name="Times New Roman" size="48.0" />
-               </font>
-            </Label>
-         </children>
-      </AnchorPane>
-      <AnchorPane layoutY="107.0" prefHeight="48.0" prefWidth="1100.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-         <children>
-            <Label layoutX="78.0" layoutY="11.0" text="&gt;" AnchorPane.leftAnchor="75.0">
-               <font>
-                  <Font size="20.0" />
-               </font>
-            </Label>
-            <Button fx:id="btnSchoolsRanking" layoutX="99.0" layoutY="10.0" mnemonicParsing="false" onAction="#processButtonClickEvents" text="Schools Ranking" AnchorPane.leftAnchor="92.0" />
-            <Button fx:id="btnHome" layoutX="14.0" layoutY="10.0" mnemonicParsing="false" onAction="#processButtonClickEvents" text="Home" AnchorPane.leftAnchor="10.0" />
-         </children>
-      </AnchorPane>
-   </children>
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0"
+            prefWidth="1100.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="edu.umuc.controllers.ManageWeightsController">
+    <children>
+        <GridPane layoutY="160.0" prefHeight="440.0" prefWidth="1100.0" AnchorPane.bottomAnchor="0.0"
+                  AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="160.0">
+            <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="1.7976931348623157E308"/>
+                <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="240.0" minWidth="240.0"
+                                   prefWidth="240.0"/>
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="25.0" minWidth="25.0" prefWidth="25.0"/>
+                <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" maxWidth="180.0" minWidth="180.0"
+                                   prefWidth="180.0"/>
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="1.7976931348623157E308"/>
+            </columnConstraints>
+            <rowConstraints>
+                <RowConstraints maxHeight="91.0" minHeight="10.0" prefHeight="60.0" vgrow="SOMETIMES"/>
+                <RowConstraints maxHeight="60.0" minHeight="60.0" prefHeight="60.0" vgrow="SOMETIMES"/>
+                <RowConstraints maxHeight="60.0" minHeight="60.0" prefHeight="60.0" vgrow="SOMETIMES"/>
+                <RowConstraints maxHeight="60.0" minHeight="60.0" prefHeight="60.0" vgrow="SOMETIMES"/>
+                <RowConstraints maxHeight="1.7976931348623157E308" vgrow="SOMETIMES"/>
+                <RowConstraints maxHeight="80.0" minHeight="80.0" prefHeight="80.0" vgrow="SOMETIMES"/>
+            </rowConstraints>
+            <children>
+                <Label prefHeight="30.0" prefWidth="88.0" text="Win-Loss" GridPane.columnIndex="1"
+                       GridPane.rowIndex="1">
+                    <font>
+                        <Font name="Times New Roman" size="20.0"/>
+                    </font>
+                </Label>
+                <TextField fx:id="winLossWeight" GridPane.columnIndex="3" GridPane.rowIndex="1"/>
+                <Label prefHeight="30.0" prefWidth="210" text="Average Opponents Wins" GridPane.columnIndex="1"
+                       GridPane.rowIndex="2">
+                    <font>
+                        <Font name="Times New Roman" size="20.0"/>
+                    </font>
+                </Label>
+                <TextField fx:id="oppWinsWeight" GridPane.columnIndex="3" GridPane.rowIndex="2"/>
+                <Label prefHeight="30.0" prefWidth="210.0" text="Average Point Difference" GridPane.columnIndex="1"
+                       GridPane.rowIndex="3">
+                    <font>
+                        <Font name="Times New Roman" size="20.0"/>
+                    </font>
+                </Label>
+                <TextField fx:id="avgPtsDiffWeight" prefHeight="31.0" prefWidth="190.0" GridPane.columnIndex="3"
+                           GridPane.rowIndex="3"/>
+                <Label prefHeight="48.0" prefWidth="67.0" text="Type" GridPane.columnIndex="1">
+                    <font>
+                        <Font name="Times New Roman" size="29.0"/>
+                    </font>
+                </Label>
+                <Label prefHeight="30.0" text="Previous Season" GridPane.columnIndex="1"
+                       GridPane.rowIndex="4">
+                    <font>
+                        <Font name="Times New Roman" size="20.0"/>
+                    </font>
+                </Label>
+                <TextField fx:id="lastSeasonPercentCalc" prefHeight="31.0" prefWidth="190.0" GridPane.columnIndex="3"
+                           GridPane.rowIndex="4"/>
+                <Label prefHeight="48.0" prefWidth="67.0" text="Type" GridPane.columnIndex="1">
+                    <font>
+                        <Font name="Times New Roman" size="29.0"/>
+                    </font>
+                </Label>
+
+                <Label prefHeight="48.0" prefWidth="91.0" text="Weight" GridPane.columnIndex="3"
+                       GridPane.halignment="CENTER">
+                    <font>
+                        <Font name="Times New Roman" size="29.0"/>
+                    </font>
+                </Label>
+
+                <Button fx:id="btnResetWeights" mnemonicParsing="false" onAction="#handleResetWeights" prefHeight="42.0"
+                        prefWidth="191.0" text="Reset Weights" textFill="#29288d" GridPane.columnIndex="1"
+                        GridPane.rowIndex="6"/>
+                <Button fx:id="btnSaveWeights" mnemonicParsing="false" onAction="#handleSaveWeights" prefHeight="42.0"
+                        prefWidth="191.0" text="Save Weights" textFill="#29288d" GridPane.columnIndex="3"
+                        GridPane.rowIndex="6"/>
+            </children>
+        </GridPane>
+        <AnchorPane prefHeight="110.0" prefWidth="1100.0" style="-fx-background-color: #23a353;"
+                    AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <children>
+                <Label alignment="CENTER" layoutX="353.0" layoutY="20.0" prefHeight="70.0" prefWidth="395.0"
+                       text="Manage Weights" textFill="WHITE" AnchorPane.leftAnchor="30.0" AnchorPane.rightAnchor="30.0"
+                       AnchorPane.topAnchor="20.0">
+                    <font>
+                        <Font name="Times New Roman" size="48.0"/>
+                    </font>
+                </Label>
+            </children>
+        </AnchorPane>
+        <AnchorPane layoutY="107.0" prefHeight="48.0" prefWidth="1100.0" AnchorPane.leftAnchor="0.0"
+                    AnchorPane.rightAnchor="0.0">
+            <children>
+                <Label layoutX="78.0" layoutY="11.0" text="&gt;" AnchorPane.leftAnchor="75.0">
+                    <font>
+                        <Font size="20.0"/>
+                    </font>
+                </Label>
+                <Button fx:id="btnSchoolsRanking" layoutX="99.0" layoutY="10.0" mnemonicParsing="false"
+                        onAction="#processButtonClickEvents" text="Schools Ranking" AnchorPane.leftAnchor="92.0"/>
+                <Button fx:id="btnHome" layoutX="14.0" layoutY="10.0" mnemonicParsing="false"
+                        onAction="#processButtonClickEvents" text="Home" AnchorPane.leftAnchor="10.0"/>
+            </children>
+        </AnchorPane>
+    </children>
 </AnchorPane>

--- a/src/main/java/edu/umuc/fxml/SchoolRanking.fxml
+++ b/src/main/java/edu/umuc/fxml/SchoolRanking.fxml
@@ -40,12 +40,46 @@
                   <Font size="15.0" />
                </font>
             </Label>
-            <Label layoutX="595.0" layoutY="31.0" prefHeight="27.0" prefWidth="68.0" text="Win-Loss" textFill="#29288d" />
-            <Label layoutX="716.0" layoutY="31.0" prefHeight="27.0" prefWidth="113.0" text="Opponents Wins" textFill="#29288d" />
-            <Label layoutX="885.0" layoutY="31.0" prefHeight="27.0" prefWidth="143.0" text="Avg. Point Difference" textFill="#29288d" />
-            <Label fx:id="lblWinLoss" layoutX="670.0" layoutY="31.0" prefHeight="27.0" prefWidth="35.0" text="0.00" textFill="#29288d" />
-            <Label fx:id="lblOppWins" layoutX="835.0" layoutY="31.0" prefHeight="27.0" prefWidth="35.0" text="0.00" textFill="#29288d" />
-            <Label fx:id="lblAvgPointDiff" layoutX="1036.0" layoutY="31.0" prefHeight="27.0" prefWidth="35.0" text="0.00" textFill="#29288d" />
+            <Label layoutX="595.0" layoutY="20.0" prefHeight="27.0" text="Previous Season" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="14.0"/>
+               </font>
+            </Label>
+            <Label layoutX="715.0" layoutY="20.0" prefHeight="27.0" text="Win-Loss" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="14.0"/>
+               </font>
+            </Label>
+            <Label layoutX="805.0" layoutY="20.0" prefHeight="27.0" text="Opponents Wins" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="14.0"/>
+               </font>
+            </Label>
+            <Label layoutX="925.0" layoutY="20.0" prefHeight="27.0" text="Avg. Point Difference" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="14.0"/>
+               </font>
+            </Label>
+            <Label fx:id="lblPreviousSeason" layoutX="595.0" layoutY="35" prefHeight="27.0" text="0.00" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="12.0"/>
+               </font>
+            </Label>
+            <Label fx:id="lblWinLoss" layoutX="715.0" layoutY="35.0" prefHeight="27.0" text="0.00" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="12.0"/>
+               </font>
+            </Label>
+            <Label fx:id="lblOppWins" layoutX="805.0" layoutY="35.0" prefHeight="27.0" text="0.00" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="12.0"/>
+               </font>
+            </Label>
+            <Label fx:id="lblAvgPointDiff" layoutX="925.0" layoutY="35" prefHeight="27.0" text="0.00" textFill="#29288d">
+               <font>
+                  <Font name="Arial" size="12.0"/>
+               </font>
+            </Label>
             <TableView fx:id="tbSchoolRanking" layoutY="68.0" prefHeight="301.0" prefWidth="1084.0" AnchorPane.bottomAnchor="6.0" AnchorPane.leftAnchor="8.0" AnchorPane.rightAnchor="8.0" AnchorPane.topAnchor="68.0">
                <columns>
                   <TableColumn fx:id="rank" prefWidth="52.0" text="Rank" />

--- a/src/main/java/edu/umuc/models/RankWeight.java
+++ b/src/main/java/edu/umuc/models/RankWeight.java
@@ -22,6 +22,11 @@ public class RankWeight {
     private float avgOppDifference;
 
     /**
+     * The weight given to last season's average in this season's calculation.
+     */
+    private float lastSeasonPercentWeight;
+
+    /**
      * Default Constructor
      */
     public RankWeight() {
@@ -37,6 +42,20 @@ public class RankWeight {
         this.winLoss = winLoss;
         this.oppWins = oppWins;
         this.avgOppDifference = avgOppDifference;
+    }
+
+    /**
+     * Constructor
+     * @param winLoss                   Weight assigned to wins and losses
+     * @param oppWins                   Weight assigned to opponent wins
+     * @param avgOppDifference          Weight assigned to average opponent point difference
+     * @param lastSeasonPercentWeight   Weight given to a team's previous season average.
+     */
+    public RankWeight(float winLoss, float oppWins, float avgOppDifference, float lastSeasonPercentWeight) {
+        this.winLoss = winLoss;
+        this.oppWins = oppWins;
+        this.avgOppDifference = avgOppDifference;
+        this.lastSeasonPercentWeight = lastSeasonPercentWeight;
     }
 
     public float getWinLoss() {
@@ -61,5 +80,13 @@ public class RankWeight {
 
     public void setAvgOppDifference(float avgOppDifference) {
         this.avgOppDifference = avgOppDifference;
+    }
+
+    public float getLastSeasonPercentWeight() {
+        return lastSeasonPercentWeight;
+    }
+
+    public void setLastSeasonPercentWeight(float lastSeasonPercentWeight) {
+        this.lastSeasonPercentWeight = lastSeasonPercentWeight;
     }
 }

--- a/src/main/java/edu/umuc/models/School.java
+++ b/src/main/java/edu/umuc/models/School.java
@@ -58,6 +58,8 @@ public class School {
      */
     private float avgOpponentWins = 0f;
 
+    private float previousYearPoints = 0f;
+
     public School() {
 
     }
@@ -237,7 +239,15 @@ public class School {
      * @return total points
      */
     public float getTotalPoints(RankWeight rankWeight, float leagueWeight) {
-        rankPoints = getSumOfPoints(rankWeight, leagueWeight) + getPointsFromOpponentWins(rankWeight) + getPointsFromAveragePointDifferential(rankWeight);
+        rankPoints = (getPreviousYearPoints() * rankWeight.getLastSeasonPercentWeight()) + getSumOfPoints(rankWeight, leagueWeight) + getPointsFromOpponentWins(rankWeight) + getPointsFromAveragePointDifferential(rankWeight);
         return rankPoints;
+    }
+
+    public float getPreviousYearPoints() {
+        return previousYearPoints;
+    }
+
+    public void setPreviousYearPoints(float previousYearPoints) {
+        this.previousYearPoints = previousYearPoints;
     }
 }


### PR DESCRIPTION
- Added ability for user to assign a "weight" value to the previous season points, to be applied to all teams.
- This value exists to pull in data from a previous season when considering rankings for a new season (or early in the season).
- UI changes on Rank Schools, Rank Calculations, and Manage Weights screens
- Tested and verified correct application of weight values & ordering of teams on ranking table
